### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "name": "Money Transfer Demo",
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {},
+    "ghcr.io/devcontainers/features/go:1": {},
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "lts",
+      "installGradle": true
+    },
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-extra/features/poetry:2": {},
+    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers/features/ruby:1": {
+      "version": "3.2.8"
+    },
+    "ghcr.io/devcontainers-extra/features/temporal-cli:1": {},
+    "ghcr.io/mrsimonemms/devcontainers/tcld:1": {}
+  },
+  "forwardPorts": [
+    7070,
+	  7233,
+	  8233
+  ]
+}


### PR DESCRIPTION
Provide [devcontainer support](https://containers.dev/) to make it easier to get started without having to install any dependencies.

This also fixes the Python worker if running against the local Temporal server. Previously, there was no Temporal client created if not API key/mTLS provided.