### PR TITLE
ci: create docker image for ui to allow distribution

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "name": "Money Transfer Demo",
   "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/dotnet:2": {},
     "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/devcontainers/features/java:1": {

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,69 @@
+name: Build container images
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    strategy:
+      matrix:
+        # Images to build
+        image:
+          - ui
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: '${{ github.actor }}'
+        password: '${{ secrets.GITHUB_TOKEN }}'
+
+    - name: Generate Docker tags
+      id: docker
+      run: |
+        IMG_NAME="ghcr.io/${GITHUB_REPOSITORY,,}/${{ matrix.image }}"
+
+        PLATFORMS="linux/amd64"
+        PUSH="false"
+        TAGS="${IMG_NAME}:${{ github.sha }}"
+
+        if [ "${{ github.ref == 'refs/heads/main' }}" = "true" ]; then
+          # Add latest tag
+          TAGS="${TAGS},${IMG_NAME}:latest"
+
+          # Add date tag
+          TAGS="${TAGS},${IMG_NAME}:$(date --iso-8601)"
+
+          # Build additional image architectures
+          PLATFORMS="${PLATFORMS},linux/arm64"
+
+          # Always push to registry
+          PUSH="true"
+        fi
+
+        echo "platforms=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+        echo "push=${PUSH}" >> "$GITHUB_OUTPUT"
+        echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ matrix.image }}
+        platforms: ${{ steps.docker.outputs.platforms }}
+        push: ${{ steps.docker.outputs.push }}
+        tags: ${{ steps.docker.outputs.tags }}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu
+WORKDIR /opt/app
+COPY . .
+RUN apt update \
+    && apt install -y gradle \
+    && ./gradlew build
+EXPOSE 7070
+ENV TEMPORAL_ADDRESS=temporal:7233
+ENV TEMPORAL_NAMESPACE=default
+ENV TEMPORAL_CERT_PATH=""
+ENV TEMPORAL_KEY_PATH=""
+ENTRYPOINT [ "./startlocalwebui.sh" ]
+# Encrypt the payload
+CMD [ "false" ]

--- a/ui/src/main/java/io/temporal/samples/moneytransfer/TemporalClient.java
+++ b/ui/src/main/java/io/temporal/samples/moneytransfer/TemporalClient.java
@@ -38,7 +38,7 @@ public class TemporalClient {
                     SimpleSslContextBuilder.forPKCS8(clientCert, clientKey).build()
             );
         }
-        else if (!ServerInfo.getAddress().equals("localhost:7233")){
+        else if (!ServerInfo.getAddress().equals("localhost:7233") && !ServerInfo.getAddress().equals("temporal:7233")){
             throw new RuntimeException("You must specify either an API KEY or mTLS certificates for a non local connection");
         }
 


### PR DESCRIPTION
Create a Docker image for the `ui` to allow easy distribution for additional demos.

I have a usecase where I want an additional Money Transfer Demo for [Serverless Workflow](https://github.com/mrsimonemms/temporal-serverless-workflow). It doesn't make sense to add in here (yet), but I don't want to maintain a version of the UI.

The only change in the app is to allow `temporal:7233` as a connection string without API/mTLS authentication.

To test this, create a simple Docker Compose workflow (or use this with `docker compose up ui` - the Temporal stuff will fail as no workflow, but proves connection):

```
include:
  - oci://ghcr.io/mrsimonemms/temporal-demos/temporal-compose

services:
  ui:
    build:
      context: .
    links:
      - temporal
    depends_on:
      temporal:
        condition: service_healthy
    ports:
      - 7070:7070
```