### PR TITLE
Build docker images for the TypeScript and Go workers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -17,6 +17,7 @@ jobs:
         # Images to build
         image:
           - go
+          - typescript
           - ui
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         # Images to build
         image:
+          - go
           - ui
     steps:
     - uses: actions/checkout@v4

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang AS builder
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOCACHE=/go/.cache
+USER 1000
+WORKDIR /go/app
+COPY --chown=1000:1000 . .
+RUN go build \
+    -ldflags \
+    "-w -s" \
+    -o /go/bin/app ./worker
+COPY --from=cosmtrek/air /go/bin/air /go/bin/air
+ENTRYPOINT [ "air" ]
+
+FROM scratch
+WORKDIR /app
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /go/bin/app /app
+ENTRYPOINT [ "/app/app" ]

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts AS builder
+USER node
+WORKDIR /home/node/app
+COPY --chown=node:node . .
+RUN npm ci && \
+    npm run build
+CMD [ "npm", "run", "start.watch" ]
+
+FROM node:lts-slim
+WORKDIR /home/node/app
+COPY --from=builder /home/node/app/lib lib
+COPY --from=builder /home/node/app/package.json package.json
+COPY --from=builder /home/node/app/package-lock.json package-lock.json
+# Certs are required to use Temporal TLS connection
+RUN npm ci --include=prod \
+    && apt-get update \
+    && apt-get install -y ca-certificates
+USER node
+CMD [ "node", "lib/worker" ]


### PR DESCRIPTION
An SA discussion recently talked about restoring the online demo, which uses Kubernetes. Added config to build images for the Go and TypeScript workers (future ones can be done later) as an MVP for this proposed work.