### PR TITLE
feat: configure running in docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/
 setcloudenv.sh
 /ruby/coverage
 .vscode
+tmp

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,70 @@
+# Run your desired workflow with:
+#   docker compose up <workflow>
+
+services:
+  #############
+  # Workflows #
+  #############
+  go: &base_workflow
+    build:
+      context: ./go
+      target: builder
+    environment:
+      # Maintain envvars to allow running against Temporal Cloud
+      ENCRYPT_PAYLOADS: ${ENCRYPT_PAYLOADS:-false}
+      TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-temporal:7233}
+      TEMPORAL_NAMESPACE: ${TEMPORAL_NAMESPACE:-default}
+      TEMPORAL_API_KEY: ${TEMPORAL_API_KEY:-}
+      TEMPORAL_CERT_PATH: ${TEMPORAL_CERT_PATH:-}
+      TEMPORAL_KEY_PATH: ${TEMPORAL_KEY_PATH:-}
+      TEMPORAL_TLS: ${TEMPORAL_TLS:-false}
+    volumes:
+      - ./go:/go/app
+    links:
+      - temporal
+    depends_on:
+      temporal:
+        condition: service_healthy
+      # UI isn't actually linked, but allows us to run docker compose up go
+      ui:
+        condition: service_started
+
+  typescript:
+    <<: *base_workflow
+    build:
+      context: ./typescript
+      target: builder
+    volumes:
+      - ./typescript:/home/node/app
+
+  ################
+  # Dependencies #
+  ################
+  temporal:
+    image: temporalio/temporal
+    ports:
+      - 8233:8233
+    command: server start-dev --ip 0.0.0.0 --search-attribute Step=Keyword
+    healthcheck:
+      test: ["CMD-SHELL", "temporal operator cluster health"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+
+  ui:
+    image: ghcr.io/temporal-sa/money-transfer-demo/ui
+    links:
+      - temporal
+    environment:
+      ENCRYPT_PAYLOADS: ${ENCRYPT_PAYLOADS:-false}
+      TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-temporal:7233}
+      TEMPORAL_NAMESPACE: ${TEMPORAL_NAMESPACE:-default}
+      TEMPORAL_API_KEY: ${TEMPORAL_API_KEY:-}
+      TEMPORAL_CERT_PATH: ${TEMPORAL_CERT_PATH:-}
+      TEMPORAL_KEY_PATH: ${TEMPORAL_KEY_PATH:-}
+      TEMPORAL_TLS: ${TEMPORAL_TLS:-false}
+    depends_on:
+      temporal:
+        condition: service_healthy
+    ports:
+      - 7070:7070

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -11,6 +11,7 @@ RUN go build \
     -o /go/bin/app ./worker
 COPY --from=cosmtrek/air /go/bin/air /go/bin/air
 ENTRYPOINT [ "air" ]
+CMD [ "--build.cmd", "go build -o ./tmp/main ./worker" ]
 
 FROM scratch
 WORKDIR /app


### PR DESCRIPTION
Configures the apps with Dockerfile (UI, Go, TypeScript) to be run in Docker Compose. The idea is for apps to be run with `docker compose up <language>` (eg, `docker compose up go`) which will run the app in dev-mode (ie, live-reload) and start a Temporal server on port 8233 and the UI on port 7070.