### PR TITLE
fix: set java version to v21 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "ghcr.io/devcontainers/features/dotnet:2": {},
     "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "lts",
+      "version": "21-tem",
       "installGradle": true
     },
     "ghcr.io/devcontainers/features/node:1": {},


### PR DESCRIPTION
With the release of Java v25 in Sept 2025, this broke the devcontainer