### PR TITLE
fixed rust build setup

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,4 +6,4 @@ pnpm 9.15.9
 poetry 1.8.5
 python 3.12.12
 ruby 3.2.9
-rustc 1.95.0
+rust 1.95.0

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ asdf plugin add pnpm
 asdf plugin add poetry
 asdf plugin add python
 asdf plugin add ruby
+asdf plugin add rust
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Install and configure `asdf` per the [Getting Started Guide](https://asdf-vm.com
 ## 2. Install Plugins
 
 Add [plugins](https://asdf-vm.com/manage/plugins.html) for the tools in [.tool-versions](.tool-versions)
+
 ```sh
 asdf plugin add dotnet-core
 asdf plugin add golang
@@ -216,6 +217,14 @@ asdf plugin add pnpm
 asdf plugin add poetry
 asdf plugin add python
 asdf plugin add ruby
+```
+
+> [!NOTE]
+> Rust is deliberately excluded from the list above. If you already manage Rust with [rustup](https://rustup.rs),
+> skip this step — asdf would install a second, standalone Rust toolchain whose shims compete with rustup's on
+> your `PATH`. If you do not use rustup and want `asdf` to manage Rust for you, register the plugin:
+
+```sh
 asdf plugin add rust
 ```
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -5,8 +5,12 @@ See the main [README](../README.md) for instructions on how to use the UI.
 
 ## Prerequisites
 
+* a Rust toolchain - install via [rustup](https://rustup.rs), or have `asdf`/`mise` manage it
+  from [.tool-versions](../.tool-versions) (see [setup](../README.md#2-install-plugins))
 * [protobuf](https://protobuf.dev/) - the Temporal Rust SDK generates its protocol
   code at build time, so `protoc` must be on your `PATH` before compiling
+
+Installing `protoc`:
 
 ```bash
 # macOS
@@ -15,10 +19,6 @@ brew install protobuf
 # Debian/Ubuntu
 sudo apt-get install -y protobuf-compiler
 ```
-
-The Rust toolchain itself is pinned in [.tool-versions](../.tool-versions) and is
-installed along with `cargo` by running `asdf install` (or `mise install`) from the
-repository root.
 
 ## Compile and Run Worker Locally
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -3,6 +3,23 @@ A money transfer demo worker written using the Temporal Rust SDK, which is compa
 
 See the main [README](../README.md) for instructions on how to use the UI.
 
+## Prerequisites
+
+* [protobuf](https://protobuf.dev/) - the Temporal Rust SDK generates its protocol
+  code at build time, so `protoc` must be on your `PATH` before compiling
+
+```bash
+# macOS
+brew install protobuf
+
+# Debian/Ubuntu
+sudo apt-get install -y protobuf-compiler
+```
+
+The Rust toolchain itself is pinned in [.tool-versions](../.tool-versions) and is
+installed along with `cargo` by running `asdf install` (or `mise install`) from the
+repository root.
+
 ## Compile and Run Worker Locally
 
 ```bash


### PR DESCRIPTION
 - correct tool name from rustc to rust in .tool-versions
 - add `asdf plugin add rust` to the setup instructions
 - document the protobuf/protoc prerequisite for the rust worker